### PR TITLE
Add CORS, reorder auth, and centralize Sqlite path

### DIFF
--- a/RandomSteamGameBlazor/Server/Program.cs
+++ b/RandomSteamGameBlazor/Server/Program.cs
@@ -22,6 +22,14 @@ var builder = WebApplication.CreateBuilder(args);
     builder.Services.AddRandomSteamGame(builder.Configuration);
     builder.Services.AddSteamApiClient(builder.Configuration);
 
+    builder.Services.AddCors(options =>
+    {
+        options.AddPolicy("AllowAll", policy =>
+            policy.AllowAnyOrigin()
+                  .AllowAnyMethod()
+                  .AllowAnyHeader());
+    });
+
     builder.Services.AddSingleton<ProblemDetailsFactory, RandomSteamProblemDetailsFactory>();
 }
 
@@ -38,12 +46,13 @@ var app = builder.Build();
     }
 
     app.UseHttpsRedirection();
-    app.UseAuthentication();
-
     app.UseBlazorFrameworkFiles();
     app.UseStaticFiles();
 
     app.UseRouting();
+    app.UseCors("AllowAll");
+
+    app.UseAuthentication();
     app.UseAuthorization();
 
     app.MapRazorPages();

--- a/RandomSteamGameBlazor/Server/ServerDependencyInjection.cs
+++ b/RandomSteamGameBlazor/Server/ServerDependencyInjection.cs
@@ -49,11 +49,15 @@ public static class ServerDependencyInjection
 
     public static IServiceCollection AddAuthentication(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddAuthorization();
         var jwtSettings = new JwtSettings();
         configuration.Bind(JwtSettings.SectionName, jwtSettings);
         services.AddSingleton(Options.Create(jwtSettings));
         services.AddTransient<IJwtTokenGenerator, JwtTokenGenerator>();
+
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = null;
+        });
 
         services.AddAuthentication(opt =>
         {
@@ -81,17 +85,9 @@ public static class ServerDependencyInjection
 
         services.AddDbContext<RandomSteamContext>(opts =>
         {
-            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
             if (databaseProvider.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
             {
-                // Create folder ONLY if using Sqlite
-                var dataFolder = Path.Combine(baseDirectory, "Data");
-                Directory.CreateDirectory(dataFolder);
-
-                var dbFile = configuration.GetConnectionString("SqliteConnection");
-                var fullPath = Path.Combine(dataFolder, dbFile);
-
-                opts.UseSqlite($"Data Source={fullPath}");
+                opts.UseSqlite($"Data Source={GetSqlitePath(configuration)}");
             }
             else
             {
@@ -103,9 +99,23 @@ public static class ServerDependencyInjection
         {
             opts.SignIn.RequireConfirmedAccount = false;
         })
-        .AddEntityFrameworkStores<RandomSteamContext>()
-        .AddDefaultTokenProviders();
+            .AddEntityFrameworkStores<RandomSteamContext>()
+            .AddDefaultTokenProviders();
 
         return services;
+    }
+
+    private static string GetSqlitePath(IConfiguration configuration)
+    {
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var dataFolder = Path.Combine(baseDir, "Data");
+
+        if (!Directory.Exists(dataFolder))
+        {
+            Directory.CreateDirectory(dataFolder);
+        }
+
+        var dbFile = configuration.GetConnectionString("SqliteConnection");
+        return Path.Combine(dataFolder, dbFile);
     }
 }


### PR DESCRIPTION
Register a permissive "AllowAll" CORS policy and enable it in the request pipeline (UseCors) before authentication. Move UseAuthentication after UseCors to ensure CORS headers are applied. In DI, replace the simple AddAuthorization() call with AddAuthorization(options => options.FallbackPolicy = null) to preserve previous fallback behavior. Extract Sqlite file path creation into a GetSqlitePath helper that ensures a Data folder exists and returns the full DB path, and use that from the DbContext configuration.