### PR TITLE
Improve layout and responsive CSS for game page

### DIFF
--- a/RandomSteamGameBlazor/Client/Features/Steam/RandomGamePage.razor
+++ b/RandomSteamGameBlazor/Client/Features/Steam/RandomGamePage.razor
@@ -17,7 +17,7 @@ else
 }
 
 <div class="game-page-wrapper" style="--bg-url: url('@_background')">
-    <div class="container py-5">
+    <div class="container-fluid px-3 px-md-5 py-5">
 
         @if (!string.IsNullOrEmpty(_errorMessage))
         {

--- a/RandomSteamGameBlazor/Client/Features/Steam/RandomGamePage.razor.css
+++ b/RandomSteamGameBlazor/Client/Features/Steam/RandomGamePage.razor.css
@@ -1,4 +1,8 @@
-﻿.game-page-wrapper {
+﻿html, body {
+    overflow-x: hidden;
+}
+
+.game-page-wrapper {
     min-height: 100vh;
     width: 100%;
     background: linear-gradient(135deg, #1a0b2e 0%, #000000 100%);
@@ -11,25 +15,11 @@
     padding-top: 3rem;
     padding-bottom: 3rem;
     overflow-y: auto;
+    overflow-x: hidden;
     color: #e5e7eb;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
 }
-
-    .game-page-wrapper::-webkit-scrollbar {
-        width: 8px;
-    }
-
-    .game-page-wrapper::-webkit-scrollbar-track {
-        background: #000;
-    }
-
-    .game-page-wrapper::-webkit-scrollbar-thumb {
-        background: #374151;
-        border-radius: 4px;
-    }
-
-        .game-page-wrapper::-webkit-scrollbar-thumb:hover {
-            background: #4b5563;
-        }
 
 h1, h2 {
     color: #ffffff !important;
@@ -39,23 +29,67 @@ h1, h2 {
 #gameDescription {
     color: #cbd5e1;
     line-height: 1.6;
+    overflow-x: hidden;
+    width: 100%;
 }
 
     #gameDescription ::deep img {
+        max-width: 100% !important;
+        width: 100% !important;
+        height: auto !important;
+        display: block;
+        box-sizing: border-box;
+        margin: 1rem auto;
+    }
+
+    #gameDescription ::deep table {
         max-width: 100%;
-        height: auto;
-        border-radius: 0.5rem;
-        margin: 1rem 0;
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
     }
 
     #gameDescription ::deep a {
-        color: #38bdf8 !important;
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        word-break: break-word;
     }
 
-.container {
+    #gameDescription ::deep div,
+    #gameDescription ::deep p,
+    #gameDescription ::deep span {
+        max-width: 100%;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+    }
+
+.container, .container-fluid {
     background-color: rgba(17, 24, 39, 0.4);
     border-radius: 1rem;
     padding: 2rem;
     backdrop-filter: blur(10px);
-    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.container {
+    max-width: 1600px;
+    width: 98%;
+}
+
+.container-fluid {
+    max-width: 1700px;
+    width: 98%;
+}
+
+@media (min-width: 1800px) {
+    .container {
+        width: 95%;
+    }
+}
+
+@media (min-width: 768px) {
+    .game-page-wrapper {
+        padding-left: 2rem;
+        padding-right: 2rem;
+    }
 }


### PR DESCRIPTION
Switch page container to fluid and add horizontal padding for better edge spacing. Add global overflow-x:hidden and adjust .game-page-wrapper to prevent horizontal scroll; refine paddings and colors. Make game description content responsive: constrain images, enable horizontal scrolling for tables, and enforce word-break/wrap for links and text elements. Replace bespoke scrollbar styles and introduce responsive max-width/width rules for .container and .container-fluid with media query tweaks for large screens.